### PR TITLE
Import components without having to write the name twice

### DIFF
--- a/src/client/Routes.tsx
+++ b/src/client/Routes.tsx
@@ -10,9 +10,9 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import 'normalize.css';
 import './Global.styles.scss';
 
-import Home from './pages/Home/Home';
+import { Home } from './pages/Home';
 
-import NotFound from './pages/StatusPages/404';
+import { NotFound } from './pages/StatusPages';
 
 const client = new ApolloClient({
     link: new HttpLink(),

--- a/src/client/atoms/List/List.test.tsx
+++ b/src/client/atoms/List/List.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, cleanup } from 'react-testing-library';
 
-import List from './List';
+import { List } from './List';
 
 const originalConsole = { ...console };
 

--- a/src/client/atoms/List/List.tsx
+++ b/src/client/atoms/List/List.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import './List.styles.scss';
 
-const List: React.FC<{
+export const List: React.FC<{
     categories: string[]
     data: { [key: string]: number | string }[],
 }> = ({ categories, data }): React.ReactElement => (
@@ -33,5 +33,3 @@ const List: React.FC<{
         })}
     </div>
 );
-
-export default List;

--- a/src/client/atoms/List/index.ts
+++ b/src/client/atoms/List/index.ts
@@ -1,0 +1,1 @@
+export * from './List';

--- a/src/client/atoms/Portrait/Portrait.test.tsx
+++ b/src/client/atoms/Portrait/Portrait.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, cleanup } from 'react-testing-library';
 
-import Portrait from './Portrait';
+import { Portrait } from './Portrait';
 
 afterEach(cleanup);
 

--- a/src/client/atoms/Portrait/Portrait.tsx
+++ b/src/client/atoms/Portrait/Portrait.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import './Portrait.styles.scss';
 
-const Portrait: React.FC<{
+export const Portrait: React.FC<{
     src: string
     name: string
 }> = ({ src, name }): React.ReactElement => (
@@ -12,5 +12,3 @@ const Portrait: React.FC<{
         <p className="portrait__name">{name}</p>
     </div>
 );
-
-export default Portrait;

--- a/src/client/atoms/Portrait/index.ts
+++ b/src/client/atoms/Portrait/index.ts
@@ -1,0 +1,1 @@
+export * from './Portrait';

--- a/src/client/atoms/Ticker/Ticker.test.tsx
+++ b/src/client/atoms/Ticker/Ticker.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, cleanup } from 'react-testing-library';
 
-import Ticker from './Ticker';
+import { Ticker } from './Ticker';
 
 afterEach(cleanup);
 

--- a/src/client/atoms/Ticker/Ticker.tsx
+++ b/src/client/atoms/Ticker/Ticker.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import './Ticker.styles.scss';
 
-const Ticker: React.FC<{
+export const Ticker: React.FC<{
     title: string
     children: React.ReactElement
     unit?: {
@@ -22,5 +22,3 @@ const Ticker: React.FC<{
         })}
     </span>
 );
-
-export default Ticker;

--- a/src/client/atoms/Ticker/index.ts
+++ b/src/client/atoms/Ticker/index.ts
@@ -1,0 +1,1 @@
+export * from './Ticker';

--- a/src/client/pages/Home/Home.tsx
+++ b/src/client/pages/Home/Home.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 
 import './Home.styles.scss';
 
-const Home: React.FC<{}> = (): React.ReactElement => (
+export const Home: React.FC<{}> = (): React.ReactElement => (
     <>
         <h1>CS★Statistics</h1>
         <p>Facilitates individual and tactical development by providing the most impactful feedback based on your playstyle</p>
     </>
 );
-
-export default Home;

--- a/src/client/pages/Home/index.ts
+++ b/src/client/pages/Home/index.ts
@@ -1,0 +1,1 @@
+export * from './Home';

--- a/src/client/pages/StatusPages/403.tsx
+++ b/src/client/pages/StatusPages/403.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import StatusPage from '../../templates/StatusPage/StatusPage';
+import { StatusPage } from '../../templates/StatusPage';
 
 export const Forbidden: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
     <StatusPage

--- a/src/client/pages/StatusPages/403.tsx
+++ b/src/client/pages/StatusPages/403.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import StatusPage from '../../templates/StatusPage/StatusPage';
 
-const Forbidden: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
+export const Forbidden: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
     <StatusPage
         error={{
             code: 403,
@@ -11,5 +11,3 @@ const Forbidden: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
         msg={msg}
     />
 );
-
-export default Forbidden;

--- a/src/client/pages/StatusPages/404.tsx
+++ b/src/client/pages/StatusPages/404.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import StatusPage from '../../templates/StatusPage/StatusPage';
 
-const NotFound: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
+export const NotFound: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
     <StatusPage
         error={{
             code: 404,
@@ -11,5 +11,3 @@ const NotFound: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
         msg={msg}
     />
 );
-
-export default NotFound;

--- a/src/client/pages/StatusPages/404.tsx
+++ b/src/client/pages/StatusPages/404.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import StatusPage from '../../templates/StatusPage/StatusPage';
+import { StatusPage } from '../../templates/StatusPage';
 
 export const NotFound: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
     <StatusPage

--- a/src/client/pages/StatusPages/500.tsx
+++ b/src/client/pages/StatusPages/500.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import StatusPage from '../../templates/StatusPage/StatusPage';
 
-const InternalServerError: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
+export const InternalServerError: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
     <StatusPage
         error={{
             code: 500,
@@ -11,5 +11,3 @@ const InternalServerError: React.FC<{ msg: string }> = ({ msg }): React.ReactEle
         msg={msg}
     />
 );
-
-export default InternalServerError;

--- a/src/client/pages/StatusPages/500.tsx
+++ b/src/client/pages/StatusPages/500.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import StatusPage from '../../templates/StatusPage/StatusPage';
+import { StatusPage } from '../../templates/StatusPage';
 
 export const InternalServerError: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
     <StatusPage

--- a/src/client/pages/StatusPages/503.tsx
+++ b/src/client/pages/StatusPages/503.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import StatusPage from '../../templates/StatusPage/StatusPage';
 
-const ServiceUnavailable: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
+export const ServiceUnavailable: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
     <StatusPage
         error={{
             code: 503,
@@ -11,5 +11,3 @@ const ServiceUnavailable: React.FC<{ msg: string }> = ({ msg }): React.ReactElem
         msg={msg}
     />
 );
-
-export default ServiceUnavailable;

--- a/src/client/pages/StatusPages/503.tsx
+++ b/src/client/pages/StatusPages/503.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import StatusPage from '../../templates/StatusPage/StatusPage';
+import { StatusPage } from '../../templates/StatusPage';
 
 export const ServiceUnavailable: React.FC<{ msg: string }> = ({ msg }): React.ReactElement => (
     <StatusPage

--- a/src/client/pages/StatusPages/index.ts
+++ b/src/client/pages/StatusPages/index.ts
@@ -1,0 +1,4 @@
+export * from './403';
+export * from './404';
+export * from './500';
+export * from './503';

--- a/src/client/templates/StatusPage/StatusPage.tsx
+++ b/src/client/templates/StatusPage/StatusPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import './StatusPage.styles.scss';
 
-const StatusPage: React.FC<{
+export const StatusPage: React.FC<{
     error: {
         code: number
         text: string
@@ -17,5 +17,3 @@ const StatusPage: React.FC<{
         {msg && <p className="status-page__msg">{msg}</p>}
     </div>
 );
-
-export default StatusPage;

--- a/src/client/templates/StatusPage/index.ts
+++ b/src/client/templates/StatusPage/index.ts
@@ -1,0 +1,1 @@
+export * from './StatusPage';

--- a/src/server/api/SteamProfile/SteamProfile.ts
+++ b/src/server/api/SteamProfile/SteamProfile.ts
@@ -3,7 +3,7 @@ import { makeExecutableSchema, ApolloError } from 'apollo-server-express';
 import { SteamProfile, QuerySteamProfileArgs } from 'generated/graphql/types-server';
 import isdev from 'isdev';
 
-import SteamProfileController from '../../controllers/SteamProfileController/SteamProfileController';
+import { SteamProfileController } from '../../controllers/SteamProfileController';
 
 import typeDefs from './SteamProfile.graphql';
 

--- a/src/server/api/SteamProfile/SteamProfile.ts
+++ b/src/server/api/SteamProfile/SteamProfile.ts
@@ -15,7 +15,7 @@ class DevModeError extends ApolloError {
     }
 }
 
-export default makeExecutableSchema({
+export const SteamProfileSchema = makeExecutableSchema({
     typeDefs,
     resolvers: {
         Query: {

--- a/src/server/api/SteamProfile/index.ts
+++ b/src/server/api/SteamProfile/index.ts
@@ -1,0 +1,1 @@
+export * from './SteamProfile';

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -1,6 +1,6 @@
 import { mergeSchemas } from 'graphql-tools';
 
-import SteamProfile from './SteamProfile/SteamProfile';
+import { SteamProfileSchema as SteamProfile } from './SteamProfile';
 
 export default mergeSchemas({
     schemas: [

--- a/src/server/components/webpack/HotModuleReplacement.ts
+++ b/src/server/components/webpack/HotModuleReplacement.ts
@@ -8,7 +8,7 @@ import wpDevConfigFile from '../../../../webpack.dev';
 const wpDevConfig: webpack.Configuration = wpDevConfigFile;
 const compiler: webpack.Compiler = webpack(wpDevConfig);
 
-export default (app: express.Express): Promise<void> => new Promise((resolve): void => {
+export const HotModuleReplacement = (app: express.Express): Promise<void> => new Promise((resolve): void => {
     const { publicPath = '/' } = wpDevConfig.output || {};
 
     app.use(wpDevMiddleware(compiler, {

--- a/src/server/controllers/SteamProfileController/SteamProfileController.test.ts
+++ b/src/server/controllers/SteamProfileController/SteamProfileController.test.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import SteamProfileController from './SteamProfileController';
+import { SteamProfileController } from './SteamProfileController';
 
 jest.mock('axios');
 

--- a/src/server/controllers/SteamProfileController/SteamProfileController.ts
+++ b/src/server/controllers/SteamProfileController/SteamProfileController.ts
@@ -29,7 +29,7 @@ interface ISteamProfile {
     timecreated?: string
 }
 
-export default async (id: string): Promise<ISteamProfile> => {
+export const SteamProfileController = async (id: string): Promise<ISteamProfile> => {
     let steam64 = null;
 
     try {

--- a/src/server/controllers/SteamProfileController/index.ts
+++ b/src/server/controllers/SteamProfileController/index.ts
@@ -1,0 +1,1 @@
+export * from './SteamProfileController';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -12,8 +12,8 @@ import mongoose from 'mongoose';
 import isdev from 'isdev';
 import chalk from 'chalk';
 
-import HMR from './components/webpack/HotModuleReplacement';
-import logger from '../utilities/logger/logger';
+import { HotModuleReplacement as HMR } from './components/webpack/HotModuleReplacement';
+import { logger } from '../utilities/logger';
 import api from './api';
 
 const app: express.Express = express();

--- a/src/utilities/apolloTests/ApolloTests.tsx
+++ b/src/utilities/apolloTests/ApolloTests.tsx
@@ -14,7 +14,7 @@ const createClient = (mocks: MockedResponse[]): any => new ApolloClient({
 
 const waitForNextTick = (): Promise<void> => new Promise((res): any => setTimeout(res, 0));
 
-export default async (mocks: MockedResponse[], component: JSX.Element): Promise<RenderResult> => {
+export const renderHooks = async (mocks: MockedResponse[], component: JSX.Element): Promise<RenderResult> => {
     const container = render(
         <ApolloProvider client={createClient(mocks)}>
             {component}

--- a/src/utilities/apolloTests/index.ts
+++ b/src/utilities/apolloTests/index.ts
@@ -1,0 +1,1 @@
+export * from './ApolloTests';

--- a/src/utilities/createModel/createModel.ts
+++ b/src/utilities/createModel/createModel.ts
@@ -10,7 +10,7 @@ interface IModelBase<TSchema> {
 }
 
 // eslint-disable-next-line arrow-parens
-export default <TSchema> (
+export const createModel = <TSchema> (
     collection: string,
     schema: TCustomSchema<TSchema>,
 ): (database: mongoose.Connection) => IModelBase<TSchema> => {

--- a/src/utilities/createModel/index.ts
+++ b/src/utilities/createModel/index.ts
@@ -1,0 +1,1 @@
+export * from './createModel';

--- a/src/utilities/logger/index.ts
+++ b/src/utilities/logger/index.ts
@@ -1,0 +1,1 @@
+export * from './logger';

--- a/src/utilities/logger/logger.ts
+++ b/src/utilities/logger/logger.ts
@@ -1,7 +1,7 @@
 import signale from 'signale';
 import isdev from 'isdev';
 
-export default {
+export const logger = {
     ...signale,
     debug: isdev ? signale.debug : (): void => { },
 };


### PR DESCRIPTION
As a quality of life change, imports should not require having to write the component name twice, it just looks messy.