### PR TITLE
Refactor custom properties

### DIFF
--- a/src/client/atoms/List/List.styles.scss
+++ b/src/client/atoms/List/List.styles.scss
@@ -5,7 +5,7 @@
         grid-auto-flow: column;
         grid-auto-columns: 1fr;
 
-        padding: var(--list__row__padding, 0.25rem);
+        padding: var(--list-row-spacing, 0.25rem);
 
         &--head {
             font-size: var(--font-size-3);
@@ -16,10 +16,10 @@
         &--body {
             font-size: var(--font-size-1);
 
-            background-color: var(--list__row__background-color);
+            background-color: var(--list-row-color);
 
             &:nth-child(odd) {
-                background-color: var(--list__row__background-color, rgba(white, 0.1));
+                background-color: var(--list-row-color, rgba(white, 0.1));
             }
         }
     }

--- a/src/client/atoms/List/List.styles.scss
+++ b/src/client/atoms/List/List.styles.scss
@@ -5,7 +5,7 @@
         grid-auto-flow: column;
         grid-auto-columns: 1fr;
 
-        padding: var(--list__row-p-padding, 0.25rem);
+        padding: var(--list__row__padding, 0.25rem);
 
         &--head {
             font-size: var(--font-size-3);
@@ -16,10 +16,10 @@
         &--body {
             font-size: var(--font-size-1);
 
-            background-color: var(--list__row-p-background-color);
+            background-color: var(--list__row__background-color);
 
             &:nth-child(odd) {
-                background-color: var(--list__row-p-background-color, rgba(white, 0.1));
+                background-color: var(--list__row__background-color, rgba(white, 0.1));
             }
         }
     }

--- a/src/client/atoms/Portrait/Portrait.stories.tsx
+++ b/src/client/atoms/Portrait/Portrait.stories.tsx
@@ -12,7 +12,7 @@ storiesOf('Atoms|Portrait', module)
             margin: '0 auto',
             marginTop: '2rem',
             width: '11.5rem',
-            '--portrait__img-p-width': '75%',
+            '--portrait__img__width': '75%',
         }}
         >
             <Portrait

--- a/src/client/atoms/Portrait/Portrait.stories.tsx
+++ b/src/client/atoms/Portrait/Portrait.stories.tsx
@@ -12,7 +12,7 @@ storiesOf('Atoms|Portrait', module)
             margin: '0 auto',
             marginTop: '2rem',
             width: '11.5rem',
-            '--portrait__img__width': '75%',
+            '--portrait-img-width': '75%',
         }}
         >
             <Portrait

--- a/src/client/atoms/Portrait/Portrait.styles.scss
+++ b/src/client/atoms/Portrait/Portrait.styles.scss
@@ -4,21 +4,21 @@
     flex-direction: column;
     place-items: center center;
 
-    width: var(--portrait-p-width, 100%);
+    width: var(--portrait__width, 100%);
 
     &__img {
         object-fit: cover;
 
-        width: var(--portrait__img-p-width, 100%);
-        height: var(--portrait__img-p-width, 100%);
+        width: var(--portrait__img__width, 100%);
+        height: var(--portrait__img__width, 100%);
 
         border-radius: 50%;
     }
 
     &__name {
-        margin-top: var(--portrait-p-spacing, 1rem);
+        margin-top: var(--portrait__spacing, 1rem);
 
-        font-size: var(--portrait__name-p-size, var(--font-size-5));
-        color: var(--portrait__name-p-color, var(--theme-text));
+        font-size: var(--portrait__name__size, var(--font-size-5));
+        color: var(--portrait__name__color, var(--theme-text));
     }
 }

--- a/src/client/atoms/Portrait/Portrait.styles.scss
+++ b/src/client/atoms/Portrait/Portrait.styles.scss
@@ -4,21 +4,21 @@
     flex-direction: column;
     place-items: center center;
 
-    width: var(--portrait__width, 100%);
+    width: var(--portrait-width, 100%);
 
     &__img {
         object-fit: cover;
 
-        width: var(--portrait__img__width, 100%);
-        height: var(--portrait__img__width, 100%);
+        width: var(--portrait-img-width, 100%);
+        height: var(--portrait-img-width, 100%);
 
         border-radius: 50%;
     }
 
     &__name {
-        margin-top: var(--portrait__spacing, 1rem);
+        margin-top: var(--portrait-gap, 1rem);
 
-        font-size: var(--portrait__name__size, var(--font-size-5));
-        color: var(--portrait__name__color, var(--theme-text));
+        font-size: var(--portrait-name-size, var(--font-size-5));
+        color: var(--portrait-name-color, var(--theme-text));
     }
 }

--- a/src/client/atoms/Ticker/Ticker.styles.scss
+++ b/src/client/atoms/Ticker/Ticker.styles.scss
@@ -27,11 +27,11 @@
             border-radius: 1rem;
 
             transition: 100ms;
-            transform: translateX(var(--ticker__content--underline__position, -100%));
+            transform: translateX(var(--ticker-underline-pos, -100%));
         }
 
         &:hover {
-            --ticker__content--underline__position: 0;
+            --ticker-underline-pos: 0;
         }
 
         font-size: var(--font-size-3);

--- a/src/client/atoms/Ticker/Ticker.styles.scss
+++ b/src/client/atoms/Ticker/Ticker.styles.scss
@@ -27,11 +27,11 @@
             border-radius: 1rem;
 
             transition: 100ms;
-            transform: translateX(var(--ticker__content--underline-p-position, -100%));
+            transform: translateX(var(--ticker__content--underline__position, -100%));
         }
 
         &:hover {
-            --ticker__content--underline-p-position: 0;
+            --ticker__content--underline__position: 0;
         }
 
         font-size: var(--font-size-3);


### PR DESCRIPTION
Currently, the custom properties names are too complex to remember due to formatting and length.

The following can be done to help:
  - Remove characters that do not help describe the property or help with namespacing
  - Reduce the specificity of the name
    - `background-color` -> `color`
  - Use common terminology if possible
	- `padding/margin` -> `spacing`